### PR TITLE
Improve demo command visibility, data storage, and age-based scoring

### DIFF
--- a/Knot-Mesh/mesh_db.py
+++ b/Knot-Mesh/mesh_db.py
@@ -193,6 +193,7 @@ class MeshDB:
             'CreatorScore': 0,
             'ViewerScore': {},
             'CategoryScores': {},
+            'PreferredCategories': [],
             'created_at': time.time(),
         }
         self.store.save_user(user)
@@ -244,6 +245,10 @@ class MeshDB:
         for cat in post['Categories']:
             cat_scores[cat] = cat_scores.get(cat, 0) + points
         user['CategoryScores'] = cat_scores
+        sorted_cats = sorted(
+            cat_scores.items(), key=lambda item: item[1], reverse=True
+        )
+        user['PreferredCategories'] = [c for c, _ in sorted_cats[:3]]
 
         self.store.save_post(post)
         self.store.save_user(user)

--- a/Knot-Mesh/test_mesh_db.py
+++ b/Knot-Mesh/test_mesh_db.py
@@ -3,7 +3,7 @@ import tempfile
 from mesh_db import MeshDB, MeshStore
 
 
-def test_category_scores_persist_without_top_categories():
+def test_preferred_categories_tracked():
     with tempfile.TemporaryDirectory() as tmpdir:
         store = MeshStore(tmpdir)
         db = MeshDB(store)
@@ -11,14 +11,13 @@ def test_category_scores_persist_without_top_categories():
         db.create_user('creator', 'female')
         db.create_post('p1', 'creator', ['Cat1'])
         db.create_post('p2', 'creator', ['Cat2'])
+        db.create_post('p3', 'creator', ['Cat3'])
         db.record_engagement('u1', 'p1', 'like')  # Cat1 +1
         db.record_engagement('u1', 'p2', 'share')  # Cat2 +3
+        db.record_engagement('u1', 'p3', 'comment')  # Cat3 +2
         user = store.load_user('u1')
-        assert user['CategoryScores'] == {'Cat1': 1, 'Cat2': 3}
-        assert 'TopCategories' not in user
-        path, users_data = store._find_user_file('u1')
-        assert path is not None and users_data is not None
-        assert 'TopCategories' not in users_data['u1']
+        assert user['CategoryScores'] == {'Cat1': 1, 'Cat2': 3, 'Cat3': 2}
+        assert user['PreferredCategories'] == ['Cat2', 'Cat3', 'Cat1']
 
 
 def test_gift_updates_post_and_user():
@@ -34,3 +33,20 @@ def test_gift_updates_post_and_user():
         assert post['Score'] == 5
         user = store.load_user('u1')
         assert user['CategoryScores'] == {'Cat1': 5}
+
+
+def test_post_age_tracked():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = MeshStore(tmpdir)
+        db = MeshDB(store)
+        db.create_user('u1', 'male')
+        db.create_user('creator', 'female')
+        db.create_post('p1', 'creator', ['Cat1'])
+        db.record_engagement('u1', 'p1', 'like')
+        # make post appear 2 hours older
+        path, posts_data = store._find_post_file('p1')
+        assert path is not None and posts_data is not None
+        posts_data['p1']['created_at'] -= 7200
+        store._atomic_write(path, posts_data)
+        post = store.load_post('p1')
+        assert post['Age'] >= 2

--- a/demo.py
+++ b/demo.py
@@ -1,4 +1,5 @@
 """Interactive demo tying Mesh, Veil, Scribe and Drift together."""
+from pathlib import Path
 import shlex
 import uuid
 from typing import Callable, Dict
@@ -13,12 +14,21 @@ veil: Veil
 scribe: Scribe
 drift: Drift
 COMMANDS: Dict[str, Callable]
+DATA_DIR = Path("Knot-Mesh")
+
+
+def show_commands() -> None:
+    """Display available commands."""
+    print("Available commands:")
+    for name in sorted(COMMANDS):
+        print(f"  {name}")
+    print("  exit")
 
 
 def post(path: str) -> None:
-    tags = veil.classify(path)
-    pid = mesh.create_post(path, tags)
-    print(f"Posted {pid} with tags {tags}")
+    pid = mesh.create_post(path, veil=veil)
+    post = mesh.get_post(pid)
+    print(f"Posted {pid} with tags {post['tags']}")
 
 
 def like(pid: str) -> None:
@@ -61,15 +71,22 @@ def search(query: str) -> None:
 
 
 def populate_users(n: int) -> None:
+    users_dir = DATA_DIR / "users"
+    users_dir.mkdir(parents=True, exist_ok=True)
     for i in range(n):
-        mesh.add_user(f"user{i+1}")
+        name = f"user{i+1}"
+        mesh.add_user(name)
+        (users_dir / f"{name}.json").touch()
     print(f"Added {n} users")
 
 
 def populate_videos(n: int) -> None:
+    videos_dir = DATA_DIR / "videos"
+    videos_dir.mkdir(parents=True, exist_ok=True)
     for i in range(n):
-        path = f"sample_video_{i+1}.mp4"
-        pid = mesh.create_post(path, veil.classify(path))
+        path = videos_dir / f"sample_video_{i+1}.mp4"
+        path.touch()
+        mesh.create_post(str(path), veil=veil)
     print(f"Added {n} videos")
 
 
@@ -82,7 +99,8 @@ def setup(user_id: str) -> None:
     """Initialise module globals for a demo session."""
     global mesh, veil, scribe, drift, COMMANDS
 
-    mesh = Mesh(path=f"mesh_data_{user_id}.json")
+    DATA_DIR.mkdir(exist_ok=True)
+    mesh = Mesh(path=str(DATA_DIR / f"mesh_data_{user_id}.json"))
     veil = Veil()
     scribe = Scribe(mesh)
     drift = Drift()
@@ -99,6 +117,7 @@ def setup(user_id: str) -> None:
         "populate_users": lambda args: populate_users(int(args[0])),
         "populate_videos": lambda args: populate_videos(int(args[0])),
         "populate_categories": lambda args: populate_categories(int(args[0])),
+        "help": lambda args: show_commands(),
     }
 
 
@@ -108,6 +127,7 @@ def main() -> None:
     setup(user_id)
     mesh.add_user(f"user_{user_id}", uid=user_id)
     print(f"userID {user_id}")
+    show_commands()
 
     while True:
         try:

--- a/drift.py
+++ b/drift.py
@@ -1,12 +1,32 @@
 """Drift module: ranking algorithms for posts."""
 from typing import Dict, List, Tuple
+import time
+import math
 
 
 class Drift:
     """Ranks posts given engagement statistics."""
 
-    def rank(self, posts: Dict[str, Dict], algorithm: str = "simple") -> List[Tuple[str, Dict, int]]:
-        ranked: List[Tuple[str, Dict, int]] = []
+    def _age_factor(self, created_at: float) -> float:
+        """Return a decay factor based on post age.
+
+        Uses a logarithmic decay so that items reach zero score after
+        three months (≈90 days). New posts have a factor near 1.
+        """
+
+        max_age_days = 90
+        age_days = (time.time() - created_at) / 86400
+        if age_days >= max_age_days:
+            return 0.0
+        return max(
+            0.0,
+            1 - math.log(age_days + 1) / math.log(max_age_days + 1),
+        )
+
+    def rank(
+        self, posts: Dict[str, Dict], algorithm: str = "simple"
+    ) -> List[Tuple[str, Dict, float]]:
+        ranked: List[Tuple[str, Dict, float]] = []
         for pid, post in posts.items():
             if algorithm == "feedback":
                 score = (
@@ -22,6 +42,10 @@ class Drift:
                     + post["shares"] * 2
                     + post["gifts"] * 3
                 )
+            factor = self._age_factor(post.get("created_at", time.time()))
+            score *= factor
+            if score <= 0:
+                continue
             ranked.append((pid, post, score))
         ranked.sort(key=lambda x: x[2], reverse=True)
         return ranked

--- a/mesh.py
+++ b/mesh.py
@@ -2,7 +2,10 @@
 import json
 import os
 import uuid
+import time
 from typing import Dict, List, Tuple, Optional
+
+from veil import Veil
 
 
 class Mesh:
@@ -39,16 +42,25 @@ class Mesh:
         return uid
 
     # post operations
-    def create_post(self, content_path: str, tags: List[str]) -> str:
+    def create_post(
+        self, content_path: str, tags: Optional[List[str]] = None, veil: Optional[Veil] = None
+    ) -> str:
         data = self._load()
         pid = str(uuid.uuid4())
+        if tags is None:
+            if veil is None:
+                raise ValueError("Either tags or a Veil instance must be provided")
+            tags = veil.classify(content_path)
+        if len(tags) < 3:
+            raise ValueError("Post requires three categories")
         data["posts"][pid] = {
             "path": content_path,
-            "tags": tags,
+            "tags": tags[:3],
             "likes": 0,
             "comments": 0,
             "gifts": 0,
             "shares": 0,
+            "created_at": time.time(),
         }
         self._save(data)
         return pid

--- a/tests/test_drift_age.py
+++ b/tests/test_drift_age.py
@@ -1,0 +1,18 @@
+import time
+from drift import Drift
+
+
+def test_age_log_decay_and_filter():
+    d = Drift()
+    now = time.time()
+    posts = {
+        'fresh': {'likes': 10, 'comments': 0, 'shares': 0, 'gifts': 0, 'created_at': now},
+        'mid': {'likes': 10, 'comments': 0, 'shares': 0, 'gifts': 0, 'created_at': now - 45 * 86400},
+        'old': {'likes': 1000, 'comments': 0, 'shares': 0, 'gifts': 0, 'created_at': now - 91 * 86400},
+    }
+    ranked = d.rank(posts)
+    ids = [pid for pid, _, _ in ranked]
+    assert 'old' not in ids
+    assert ids[0] == 'fresh'
+    assert len(ranked) == 2
+    assert ranked[1][2] < ranked[0][2]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,8 +12,7 @@ def test_end_to_end(tmp_path):
     s = Scribe(m)
     d = Drift()
     path = "fun_music_clip.mp4"
-    tags = v.classify(path)
-    pid = m.create_post(path, tags)
+    pid = m.create_post(path, veil=v)
     m.increment(pid, "likes")
     results = s.search("#music")
     assert results and results[0][0] == pid

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -6,7 +6,7 @@ def test_mesh_crud(tmp_path):
     m = Mesh(str(path))
     uid = m.add_user("Alice")
     assert uid
-    pid = m.create_post("video.mp4", ["fun"])
+    pid = m.create_post("video.mp4", ["fun", "music", "travel"])
     assert pid
     post = m.get_post(pid)
     assert post["path"] == "video.mp4"

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -4,7 +4,7 @@ from scribe import Scribe
 
 def test_search_text_and_tag(tmp_path):
     m = Mesh(str(tmp_path / "data.json"))
-    pid = m.create_post("travel_to_paris.mp4", ["travel"])
+    pid = m.create_post("travel_to_paris.mp4", ["travel", "fun", "music"])
     s = Scribe(m)
     text_results = s.search("paris")
     tag_results = s.search("#travel")

--- a/tools/gen_sample.py
+++ b/tools/gen_sample.py
@@ -16,7 +16,7 @@ def generate(users: int, videos: int) -> None:
         mesh.add_user(f"user{i+1}")
     for i in range(videos):
         path = f"sample_{i+1}.mp4"
-        mesh.create_post(path, veil.classify(path))
+        mesh.create_post(path, veil=veil)
     print(f"Generated {users} users and {videos} videos")
 
 


### PR DESCRIPTION
## Summary
- show available commands on startup and via `help`
- save demo data under `Knot-Mesh` with separate users and videos folders
- wait for Veil to classify posts before saving
- track each user's three most interacted categories
- decay post ranking scores logarithmically so items older than three months drop from the feed