### PR TITLE
Add pyproject build metadata and package inits

### DIFF
--- a/Drift/__init__.py
+++ b/Drift/__init__.py
@@ -1,0 +1,2 @@
+"""Drift package initialization."""
+

--- a/Veil/__init__.py
+++ b/Veil/__init__.py
@@ -1,0 +1,2 @@
+"""Veil package."""
+

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,2 @@
+"""API package for Knot Labs."""
+

--- a/indexes/__init__.py
+++ b/indexes/__init__.py
@@ -1,0 +1,2 @@
+"""Index data package."""
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,30 @@ ignore_missing_imports = true
 warn_unused_ignores = true
 strict_optional = false
 
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "knot-labs"
+version = "0.1.0"
+description = "Knot Labs project"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "pydantic>=1.10",
+]
+
+[tool.setuptools]
+packages = [
+    "api",
+    "Mesh",
+    "Veil",
+    "Drift",
+    "Scribe",
+    "indexes",
+    "veil",
+]
+


### PR DESCRIPTION
## Summary
- add project and build metadata to `pyproject.toml`
- define packages for Mesh, Drift, Veil, etc.
- include placeholder `__init__` modules for previously missing packages

## Testing
- `pip install -e .`
- `pytest` *(fails: _tkinter.TclError: no display name and no $DISPLAY environment variable; ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c12c01ad7c832c8c1ec5afc91f2ae6