### PR TITLE
Ensure Veil CLI executes from repository root

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -125,6 +125,7 @@ def _run_veil_and_get_categories(media_path: str, topk: int = 14) -> List[str]:
                 text=True,
                 check=True,
                 env=env,
+                cwd=ROOT,
                 timeout=timeout_s,
             )
         except TypeError:
@@ -135,6 +136,7 @@ def _run_veil_and_get_categories(media_path: str, topk: int = 14) -> List[str]:
                 text=True,
                 check=True,
                 env=env,
+                cwd=ROOT,
             )
         out = (res.stdout or "") + "\n" + (res.stderr or "")
     except subprocess.TimeoutExpired:

--- a/tests/test_demo_helpers.py
+++ b/tests/test_demo_helpers.py
@@ -46,7 +46,8 @@ def test_to_category_parser_and_fallback(tmp_path, monkeypatch):
             self.stdout = text
             self.stderr = ''
 
-    def fake_run(cmd, capture_output, text, check, env):
+    def fake_run(cmd, capture_output, text, check, env, cwd=None, timeout=None):
+        assert cwd is not None  # ensure demo passes working directory
         return FakeRes('Predictions: a video about birds, a photo of foxes')
 
     monkeypatch.setattr(demo.subprocess, 'run', fake_run)


### PR DESCRIPTION
## Summary
- Run Veil CLI with the repository root as working directory to prevent fallback to sample labels
- Update demo helper test to expect the new cwd behavior